### PR TITLE
Update parrot-exec

### DIFF
--- a/bin/parrot-exec
+++ b/bin/parrot-exec
@@ -22,6 +22,6 @@ if [ $? -eq 1 ]; then
     $SHELL -s
     fi
 else
-  "$*" || true
+  $* || true
   $SHELL -s
 fi


### PR DESCRIPTION
Revert previous commit because fuck bash!

This now works as expected without the quotes.

Try to run msfvenom from the menus and you'll get /usr/bin/parrot-exec: line 25: msfvenom -h: command not found